### PR TITLE
Controller Input Triggers

### DIFF
--- a/FaderPlugin/Addon.cs
+++ b/FaderPlugin/Addon.cs
@@ -1,3 +1,4 @@
+using Dalamud.Game.ClientState.GamePad;
 using FFXIVClientStructs.FFXIV.Client.Game.Fate;
 using FFXIVClientStructs.FFXIV.Client.Game.UI;
 using FFXIVClientStructs.FFXIV.Client.Graphics;
@@ -169,6 +170,13 @@ public static unsafe class Addon
 
     public static bool InFate()
         => FateManager.Instance()->CurrentFate != null;
+
+    #endregion
+
+    #region Controller Input Check
+
+    public static bool IsControllerInputHeld(GamepadButtons button)
+        => Plugin.GamepadState.Raw(button) != 0;
 
     #endregion
 

--- a/FaderPlugin/Data/State.cs
+++ b/FaderPlugin/Data/State.cs
@@ -30,6 +30,10 @@ public enum State
     IsMoving = 20,
     Hover = 21,
     Occupied = 22,
+    LeftTrigger = 23,
+    RightTrigger = 24,
+    LeftBumper = 25,
+    RightBumper = 26,
 }
 
 
@@ -62,6 +66,10 @@ public static class StateUtil
             State.Combat => Language.StateCombat,
             State.Hover => Language.StateHover,
             State.Occupied => Language.StateOccupied,
+            State.LeftTrigger => Language.StateLeftTrigger,
+            State.RightTrigger => Language.StateRightTrigger,
+            State.LeftBumper => Language.StateLeftBumper,
+            State.RightBumper => Language.StateRightBumper,
             _ => throw new ArgumentOutOfRangeException(nameof(state), state, null)
         };
     }
@@ -91,5 +99,9 @@ public static class StateUtil
         State.ShiftKeyFocus,
         State.Hover,
         State.Occupied,
+        State.LeftTrigger,
+        State.RightTrigger,
+        State.LeftBumper,
+        State.RightBumper,
     ];
 }

--- a/FaderPlugin/Plugin.cs
+++ b/FaderPlugin/Plugin.cs
@@ -36,6 +36,8 @@ public class Plugin : IDalamudPlugin
     [PluginService] public static IGameGui GameGui { get; set; } = null!;
     [PluginService] public static ITargetManager TargetManager { get; set; } = null!;
     [PluginService] public static IDataManager Data { get; private set; } = null!;
+    [PluginService] public static IGamepadState GamepadState { get; private set; } = null!;
+    
     // Configuration and windows.
     public readonly Configuration Config;
     private readonly WindowSystem WindowSystem = new("Fader");
@@ -220,6 +222,11 @@ public class Plugin : IDalamudPlugin
         UpdateState(State.WeaponUnsheathed, Addon.IsWeaponUnsheathed());
         UpdateState(State.InSanctuary, Addon.InSanctuary());
         UpdateState(State.InFate, Addon.InFate());
+
+        UpdateState(State.LeftTrigger, Addon.IsControllerInputHeld(Dalamud.Game.ClientState.GamePad.GamepadButtons.L2));
+        UpdateState(State.RightTrigger, Addon.IsControllerInputHeld(Dalamud.Game.ClientState.GamePad.GamepadButtons.R2));
+        UpdateState(State.LeftBumper, Addon.IsControllerInputHeld(Dalamud.Game.ClientState.GamePad.GamepadButtons.L1));
+        UpdateState(State.RightBumper, Addon.IsControllerInputHeld(Dalamud.Game.ClientState.GamePad.GamepadButtons.R1));
 
         var target = TargetManager.Target;
         UpdateState(State.EnemyTarget, target?.ObjectKind == ObjectKind.BattleNpc);

--- a/FaderPlugin/Resources/Language.Designer.cs
+++ b/FaderPlugin/Resources/Language.Designer.cs
@@ -897,6 +897,25 @@ namespace faderPlugin.Resources {
             }
         }
         
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Left Bumper Held.
+        /// </summary>
+        internal static string StateLeftBumper {
+            get {
+                return ResourceManager.GetString("StateLeftBumper", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Left Trigger Held.
+        /// </summary>
+        internal static string StateLeftTrigger {
+            get {
+                return ResourceManager.GetString("StateLeftTrigger", resourceCulture);
+            }
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to Mounted.
         /// </summary>
@@ -942,6 +961,24 @@ namespace faderPlugin.Resources {
             }
         }
         
+        /// <summary>
+        ///   Looks up a localized string similar to Right Bumper Held.
+        /// </summary>
+        internal static string StateRightBumper {
+            get {
+                return ResourceManager.GetString("StateRightBumper", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Right Trigger Held.
+        /// </summary>
+        internal static string StateRightTrigger {
+            get {
+                return ResourceManager.GetString("StateRightTrigger", resourceCulture);
+            }
+        }
+                
         /// <summary>
         ///   Looks up a localized string similar to SHIFT Key Focus.
         /// </summary>

--- a/FaderPlugin/Resources/Language.resx
+++ b/FaderPlugin/Resources/Language.resx
@@ -430,4 +430,16 @@ Configuration of the element that was selected first will override the rest.</va
   <data name="StateOccupied" xml:space="preserve">
       <value>Occupied</value>
   </data>
+  <data name="StateLeftBumper" xml:space="preserve">
+    <value>Left Bumper Held</value>
+  </data>
+  <data name="StateLeftTrigger" xml:space="preserve">
+    <value>Left Trigger Held</value>
+  </data>
+  <data name="StateRightBumper" xml:space="preserve">
+    <value>Right Bumper Held</value>
+  </data>
+  <data name="StateRightTrigger" xml:space="preserve">
+    <value>Right Trigger Held</value>
+  </data>
 </root>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/c350ab95-57c1-4c04-8c16-7f7b5bdcabb0)

- Adds support for controller shoulder inputs, triggers return `true` the entire time the button is held.
- Uses IGamepadState, so it should work with any controller regardless of brand, tested with standard xbox one controller.
- Uses generic language ("Bumper" and "Trigger") instead of R1/R2/L1/L2 because those identifiers are not used by all hardware/locales. 