### PR TITLE
Draft: MagitekStratagem Integration Demo

### DIFF
--- a/FaderPlugin/Data/Configuration.cs
+++ b/FaderPlugin/Data/Configuration.cs
@@ -38,6 +38,7 @@ public class Configuration : IPluginConfiguration
     public float DefaultAlpha { get; set; } = 1.0f; // 1.0f = fully opaque, 0.0f = fully transparent
     public float EnterTransitionSpeed { get; set; } = 4.0f; // alpha change per frame when fading in (4.0f = 250ms for full transition)
     public float ExitTransitionSpeed { get; set; } = 1.0f; // alpha change per frame when fading out (1.0f = 1 second for full transition)
+    public bool UseMagitekStratagemIntegration { get; set; } = false;
 
     public void Initialize()
     {

--- a/FaderPlugin/Integrations/MagitekStratagemIntegration.cs
+++ b/FaderPlugin/Integrations/MagitekStratagemIntegration.cs
@@ -1,0 +1,32 @@
+using System;
+using Dalamud.Plugin;
+
+namespace FaderPlugin.Integrations;
+
+public sealed class MagitekStratagemIntegration : IDisposable
+{
+    private readonly IDalamudPluginInterface PluginInterface;
+    private const string DataKey = "MagitekStratagemPlugin.TrackerData";
+
+    private float[]? TrackerData;
+
+    public MagitekStratagemIntegration(IDalamudPluginInterface pluginInterface)
+    {
+        PluginInterface = pluginInterface;
+    }
+
+    public void Dispose()
+    {
+        PluginInterface.RelinquishData(DataKey);
+    }
+
+    public float[]? GetTrackerData()
+    {
+        if (TrackerData == null)
+        {
+            TrackerData = PluginInterface.GetData<float[]>(DataKey);
+        }
+
+        return TrackerData;
+    }
+}

--- a/FaderPlugin/Integrations/MagitekStratagemIntegration.cs
+++ b/FaderPlugin/Integrations/MagitekStratagemIntegration.cs
@@ -5,26 +5,24 @@ namespace FaderPlugin.Integrations;
 
 public sealed class MagitekStratagemIntegration : IDisposable
 {
-    private readonly IDalamudPluginInterface PluginInterface;
     private const string DataKey = "MagitekStratagemPlugin.TrackerData";
 
     private float[]? TrackerData;
 
-    public MagitekStratagemIntegration(IDalamudPluginInterface pluginInterface)
+    public MagitekStratagemIntegration()
     {
-        PluginInterface = pluginInterface;
     }
 
     public void Dispose()
     {
-        PluginInterface.RelinquishData(DataKey);
+        Plugin.PluginInterface.RelinquishData(DataKey);
     }
 
     public float[]? GetTrackerData()
     {
         if (TrackerData == null)
         {
-            TrackerData = PluginInterface.GetData<float[]>(DataKey);
+            TrackerData = Plugin.PluginInterface.GetData<float[]>(DataKey);
         }
 
         return TrackerData;

--- a/FaderPlugin/Integrations/MagitekStratagemIntegration.cs
+++ b/FaderPlugin/Integrations/MagitekStratagemIntegration.cs
@@ -21,9 +21,7 @@ public sealed class MagitekStratagemIntegration : IDisposable
     public float[]? GetTrackerData()
     {
         if (TrackerData == null)
-        {
             TrackerData = Plugin.PluginInterface.GetData<float[]>(DataKey);
-        }
 
         return TrackerData;
     }

--- a/FaderPlugin/Plugin.cs
+++ b/FaderPlugin/Plugin.cs
@@ -126,7 +126,7 @@ public class Plugin : IDalamudPlugin
             Config.DefaultDelay = 2000;
 
         // Initialize Integrations
-        MagitekStratagemIntegration = new MagitekStratagemIntegration(PluginInterface);
+        MagitekStratagemIntegration = new MagitekStratagemIntegration();
     }
 
     public void Dispose()

--- a/FaderPlugin/Windows/Config/ConfigWindow.Settings.cs
+++ b/FaderPlugin/Windows/Config/ConfigWindow.Settings.cs
@@ -218,8 +218,8 @@ public partial class ConfigWindow
                 //
                 ImGui.TableNextRow();
                 ImGui.TableNextColumn();
-                ImGui.TextUnformatted("Language.SettingsMagitekStratagemIntegration");
-                ImGuiComponents.HelpMarker("Language.SettingsMagitekStratagemIntegrationTooltip");
+                ImGui.TextUnformatted("Magitek Stratagem Integration");
+                ImGuiComponents.HelpMarker("Use Magitek Stratagem's eyelook position as a second mouse for hover events.");
                 ImGui.TableNextColumn();
                 ImGui.SetNextItemWidth(-1);
                 var magitekIntegration = Configuration.UseMagitekStratagemIntegration;

--- a/FaderPlugin/Windows/Config/ConfigWindow.Settings.cs
+++ b/FaderPlugin/Windows/Config/ConfigWindow.Settings.cs
@@ -194,6 +194,22 @@ public partial class ConfigWindow
                     Configuration.ExitTransitionSpeed = 1000.0f / exitTransitionTimeMs;
                     Configuration.Save();
                 }
+
+                //
+                // MagitekStratagem Integration
+                //
+                ImGui.TableNextRow();
+                ImGui.TableNextColumn();
+                ImGui.TextUnformatted("Language.SettingsMagitekStratagemIntegration");
+                ImGuiComponents.HelpMarker("Language.SettingsMagitekStratagemIntegrationTooltip");
+                ImGui.TableNextColumn();
+                ImGui.SetNextItemWidth(-1);
+                var magitekIntegration = Configuration.UseMagitekStratagemIntegration;
+                if (ImGui.Checkbox("##magitek_integration", ref magitekIntegration))
+                {
+                    Configuration.UseMagitekStratagemIntegration = magitekIntegration;
+                    Configuration.Save();
+                }
             }
         }
 


### PR DESCRIPTION
Functional Proof of Concept of integrating with MagitekStratagem to obtain Eye tracking data and use it as a "second mouse" for the purposes of Hover calculations.

Should be very performant as the implementation uses Shared Data to pass a reference to an array of floats. No IPC calls are necessary, and consumers always have access to the most recent data.

Personally, I think a better integration would have its own separate Trigger for Eyelook, but I wanted to keep modifications to the codebase at a minimum for this Proof of Concept.

Also, I was unable to edit the Resources properly as I work with Visual Code, apologies for that!