### PR TITLE
Animation Rework & Relative Opacity Option

### DIFF
--- a/FaderPlugin/Animation/Tween.cs
+++ b/FaderPlugin/Animation/Tween.cs
@@ -1,0 +1,56 @@
+using System;
+
+namespace FaderPlugin.Animation;
+
+/// <summary>
+/// Delegate for easing curves.
+/// </summary>
+/// <param name="progress">
+/// A value in [0,1] representing how far along the interpolation is.
+/// </param>
+/// <returns>
+/// The eased progress in [0,1].
+/// </returns>
+internal delegate float EasingFunc(float progress);
+
+/// <summary>
+/// Collection of easing functions for interpolation.
+/// </summary>
+internal static class Easing
+{
+    /// <summary>
+    /// Linear easing (constant speed)
+    /// </summary>
+    public static float Linear(float progress) => progress;
+
+    // TODO: add specific Easing Functions or implement cubic bezier (didn't bother since linear works really well for opacity)
+}
+
+internal class Tween(float start, float end, long startTime, long duration, EasingFunc easing)
+{
+    public float StartValue { get; } = start;
+    public float EndValue { get; } = end;
+    public long StartTime { get; } = startTime;
+    public long Duration { get; } = duration;
+    private readonly EasingFunc Easing = easing;
+
+    /// <summary>
+    /// Computes the interpolated value at the given time.
+    /// </summary>
+    public float Value(long now)
+    {
+        if (Duration <= 0)
+            return EndValue;
+
+        var elapsedTime = now - StartTime;
+        var rawProgress = elapsedTime / (float)Duration;
+        var normalizedProgress = Math.Clamp(rawProgress, 0f, 1f);
+
+        return StartValue + (EndValue - StartValue) * Easing(normalizedProgress);
+    }
+
+    /// <summary>
+    /// Indicates whether the tween has completed.
+    /// </summary>
+    public bool IsComplete(long now) => now >= StartTime + Duration;
+}

--- a/FaderPlugin/Data/Configuration.cs
+++ b/FaderPlugin/Data/Configuration.cs
@@ -38,6 +38,7 @@ public class Configuration : IPluginConfiguration
     public float DefaultAlpha { get; set; } = 1.0f; // 1.0f = fully opaque, 0.0f = fully transparent
     public float EnterTransitionSpeed { get; set; } = 4.0f; // alpha change per frame when fading in (4.0f = 250ms for full transition)
     public float ExitTransitionSpeed { get; set; } = 1.0f; // alpha change per frame when fading out (1.0f = 1 second for full transition)
+    public bool RelativeOpacity { get; set; } = false;
 
     public void Initialize()
     {

--- a/FaderPlugin/Plugin.cs
+++ b/FaderPlugin/Plugin.cs
@@ -453,7 +453,7 @@ public class Plugin : IDalamudPlugin
     {
         if (!Config.RelativeOpacity)
             return 1f;
-        
+
 
         return Addon.GetSavedOpacity(addonName);
     }

--- a/FaderPlugin/Resources/Language.Designer.cs
+++ b/FaderPlugin/Resources/Language.Designer.cs
@@ -899,6 +899,25 @@ namespace faderPlugin.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Relative Opacity.
+        /// </summary>
+        internal static string SettingsRelativeOpacity {
+            get {
+                return ResourceManager.GetString("SettingsRelativeOpacity", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to If enabled, all plugin opacity values are multiplied by your native HUD-layout opacity.
+        ///E.g., native 60% + plugin 50% → resulting UI at 30%..
+        /// </summary>
+        internal static string SettingsRelativeOpacityTooltip {
+            get {
+                return ResourceManager.GetString("SettingsRelativeOpacityTooltip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Show.
         /// </summary>
         internal static string SettingsShow {

--- a/FaderPlugin/Resources/Language.Designer.cs
+++ b/FaderPlugin/Resources/Language.Designer.cs
@@ -908,8 +908,9 @@ namespace faderPlugin.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to If enabled, all plugin opacity values are multiplied by your native HUD-layout opacity.
-        ///E.g., native 60% + plugin 50% → resulting UI at 30%..
+        ///   Looks up a localized string similar to If enabled, all plugin opacity values are multiplied by your native HUD-layout opacity. 
+        ///This way the Plugin only operates within the bounds of your stock UI.
+        ///E.g., native 60% * plugin 50% → resulting UI at 30%..
         /// </summary>
         internal static string SettingsRelativeOpacityTooltip {
             get {

--- a/FaderPlugin/Resources/Language.de.resx
+++ b/FaderPlugin/Resources/Language.de.resx
@@ -153,4 +153,10 @@
   <data name="ElementExperienceBar" xml:space="preserve">
     <value />
   </data>
+  <data name="SettingsRelativeOpacityTooltip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="SettingsRelativeOpacity" xml:space="preserve">
+    <value />
+  </data>
 </root>

--- a/FaderPlugin/Resources/Language.fr.resx
+++ b/FaderPlugin/Resources/Language.fr.resx
@@ -153,4 +153,10 @@
   <data name="ElementExperienceBar" xml:space="preserve">
     <value />
   </data>
+  <data name="SettingsRelativeOpacityTooltip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="SettingsRelativeOpacity" xml:space="preserve">
+    <value />
+  </data>
 </root>

--- a/FaderPlugin/Resources/Language.ja.resx
+++ b/FaderPlugin/Resources/Language.ja.resx
@@ -153,4 +153,10 @@
   <data name="ElementExperienceBar" xml:space="preserve">
     <value />
   </data>
+  <data name="SettingsRelativeOpacityTooltip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="SettingsRelativeOpacity" xml:space="preserve">
+    <value />
+  </data>
 </root>

--- a/FaderPlugin/Resources/Language.resx
+++ b/FaderPlugin/Resources/Language.resx
@@ -505,4 +505,11 @@ Configuration of the element that was selected first will override the rest.</va
   <data name="ElementExperienceBar" xml:space="preserve">
     <value>Experience Bar</value>
   </data>
+  <data name="SettingsRelativeOpacityTooltip" xml:space="preserve">
+    <value>If enabled, all plugin opacity values are multiplied by your native HUD-layout opacity.
+E.g., native 60% + plugin 50% → resulting UI at 30%.</value>
+  </data>
+  <data name="SettingsRelativeOpacity" xml:space="preserve">
+    <value>Relative Opacity</value>
+  </data>
 </root>

--- a/FaderPlugin/Resources/Language.resx
+++ b/FaderPlugin/Resources/Language.resx
@@ -506,8 +506,9 @@ Configuration of the element that was selected first will override the rest.</va
     <value>Experience Bar</value>
   </data>
   <data name="SettingsRelativeOpacityTooltip" xml:space="preserve">
-    <value>If enabled, all plugin opacity values are multiplied by your native HUD-layout opacity.
-E.g., native 60% + plugin 50% → resulting UI at 30%.</value>
+    <value>If enabled, all plugin opacity values are multiplied by your native HUD-layout opacity. 
+This way the Plugin only operates within the bounds of your stock UI.
+E.g., native 60% * plugin 50% → resulting UI at 30%.</value>
   </data>
   <data name="SettingsRelativeOpacity" xml:space="preserve">
     <value>Relative Opacity</value>

--- a/FaderPlugin/Windows/Config/ConfigWindow.Settings.cs
+++ b/FaderPlugin/Windows/Config/ConfigWindow.Settings.cs
@@ -18,7 +18,7 @@ public partial class ConfigWindow
 {
     private List<ConfigEntry> SelectedConfig = [];
     private readonly List<Element> SelectedElements = [];
-
+    private const float AlphaTolerance = 1f / 255f;
     private Constants.OverrideKeys CurrentOverrideKey => (Constants.OverrideKeys)Configuration.OverrideKey;
 
     private void Settings()
@@ -168,7 +168,7 @@ public partial class ConfigWindow
 
                 ImGui.TableNextColumn();
                 ImGui.SetNextItemWidth(-1);
-                var enterTransitionTimeMs = Configuration.EnterTransitionSpeed > 0.0001f
+                var enterTransitionTimeMs = Configuration.EnterTransitionSpeed > AlphaTolerance
                     ? (1.0f / Configuration.EnterTransitionSpeed) * 1000.0f
                     : 1000.0f;
                 if (Helper.SliderFloatDiscrete("##enter_transition_time_ms", ref enterTransitionTimeMs, 10.0f, 2000.0f, 10.0f, "{0:0} ms"))
@@ -187,7 +187,7 @@ public partial class ConfigWindow
 
                 ImGui.TableNextColumn();
                 ImGui.SetNextItemWidth(-1);
-                var exitTransitionTimeMs = Configuration.ExitTransitionSpeed > 0.0001f
+                var exitTransitionTimeMs = Configuration.ExitTransitionSpeed > AlphaTolerance
                     ? (1.0f / Configuration.ExitTransitionSpeed) * 1000.0f
                     : 1000.0f;
                 if (Helper.SliderFloatDiscrete("##exit_transition_time_ms", ref exitTransitionTimeMs, 10.0f, 2000.0f, 10.0f, "{0:0} ms"))
@@ -481,7 +481,7 @@ public partial class ConfigWindow
 
                 var itemWidth = 200.0f * ImGuiHelpers.GlobalScale;
                 ImGui.SetNextItemWidth(itemWidth);
-                var fadeInTime = Configuration.FadeOverrides[selectedElement].EnterTransitionSpeedOverride > 0.0001f
+                var fadeInTime = Configuration.FadeOverrides[selectedElement].EnterTransitionSpeedOverride > AlphaTolerance
                     ? (1.0f / Configuration.FadeOverrides[selectedElement].EnterTransitionSpeedOverride) * 1000.0f
                     : 1000.0f;
                 if (Helper.SliderFloatDiscrete($"##{elementName}-fadeIn", ref fadeInTime, 10.0f, 2000.0f, 10.0f, "{0:0} ms"))
@@ -497,7 +497,7 @@ public partial class ConfigWindow
                 ImGui.TableNextColumn();
 
                 ImGui.SetNextItemWidth(itemWidth);
-                var fadeOutTime = Configuration.FadeOverrides[selectedElement].ExitTransitionSpeedOverride > 0.0001f
+                var fadeOutTime = Configuration.FadeOverrides[selectedElement].ExitTransitionSpeedOverride > AlphaTolerance
                     ? (1.0f / Configuration.FadeOverrides[selectedElement].ExitTransitionSpeedOverride) * 1000.0f
                     : 1000.0f;
                 if (Helper.SliderFloatDiscrete($"##{elementName}-fadeOut", ref fadeOutTime, 10.0f, 2000.0f, 10.0f, "{0:0} ms"))

--- a/FaderPlugin/Windows/Config/ConfigWindow.Settings.cs
+++ b/FaderPlugin/Windows/Config/ConfigWindow.Settings.cs
@@ -176,6 +176,7 @@ public partial class ConfigWindow
                     Configuration.EnterTransitionSpeed = 1000.0f / enterTransitionTimeMs;
                     Configuration.Save();
                 }
+
                 //
                 // Exit Transition Time
                 //
@@ -192,6 +193,23 @@ public partial class ConfigWindow
                 if (Helper.SliderFloatDiscrete("##exit_transition_time_ms", ref exitTransitionTimeMs, 10.0f, 2000.0f, 10.0f, "{0:0} ms"))
                 {
                     Configuration.ExitTransitionSpeed = 1000.0f / exitTransitionTimeMs;
+                    Configuration.Save();
+                }
+
+                //
+                // Relative Opacity
+                //
+                ImGui.TableNextRow();
+                ImGui.TableNextColumn();
+                ImGui.TextUnformatted(Language.SettingsRelativeOpacity);
+                ImGuiComponents.HelpMarker(Language.SettingsRelativeOpacityTooltip);
+
+                ImGui.TableNextColumn();
+                ImGui.SetNextItemWidth(-1);
+                var relativeOpacity = Configuration.RelativeOpacity;
+                if (ImGui.Checkbox("##relative_opacity_enabled", ref relativeOpacity))
+                {
+                    Configuration.RelativeOpacity = relativeOpacity;
                     Configuration.Save();
                 }
             }


### PR DESCRIPTION
**Reworked Animation Behavior**  
   - Fixed an issue where the opacity sometimes finished animating faster than the specified duration
   - Refactored Animation Logic into its own class (currently only has a linear easing function, but can be easily expanded)

**Added “Relative Opacity” Option**  
   - When enabled, the plugin multiplies its own opacity setting by the HUD’s native opacity, preserving the original layout’s settings.  
   - **Example:**  
     - Native HUD hotbar opacity = 60%  
     - Plugin opacity = 50% → Result = 0.6 × 0.5 = 30% visible  
     - Plugin opacity = 100% → Result = 0.6 × 1.0 = 60% visible  