### PR TITLE
Relative Opacity Jobbars & crossbar fix

### DIFF
--- a/FaderPlugin/Addon.cs
+++ b/FaderPlugin/Addon.cs
@@ -1,4 +1,5 @@
 using Dalamud.Game.ClientState.GamePad;
+using FaderPlugin.Data;
 using FFXIVClientStructs.FFXIV.Client.Game.Fate;
 using FFXIVClientStructs.FFXIV.Client.Game.UI;
 using FFXIVClientStructs.FFXIV.Client.Graphics;
@@ -20,6 +21,8 @@ public static unsafe class Addon
 
     private static readonly Dictionary<string, (short X, short Y)> StoredPositions = [];
 
+    private static readonly HashSet<string> JobAddonNames = [.. ElementUtil.GetAddonName(Element.Job)];
+
     #region Visibility and Position
 
     /// <summary>
@@ -27,11 +30,14 @@ public static unsafe class Addon
     /// </summary>
     public static float GetSavedOpacity(string addonName)
     {
-        var config = AddonConfig.Instance();
-        if (config == null || config->ModuleData == null)
+        if (JobAddonNames.Contains(addonName))
             return 1.0f;
 
-        var data = config->ModuleData;
+        var config = AddonConfig.Instance();
+        if (config == null || config->ActiveDataSet == null)
+            return 1.0f;
+
+        var data = config->ActiveDataSet;
         var addons = data->HudLayoutConfigEntries;     // 440
         var layouts = data->HudLayoutNames.Length;     // 4
         var addonsPerLayout = addons.Length / layouts; // 440/4 = 110
@@ -50,7 +56,6 @@ public static unsafe class Addon
 
             return addons[i].Alpha / 255f;
         }
-
         // fallback if not found (e.g. Chat, since you can't natively adjust its opacity)
         return 1.0f;
     }

--- a/FaderPlugin/Addon.cs
+++ b/FaderPlugin/Addon.cs
@@ -22,7 +22,7 @@ public static unsafe class Addon
 
     private static readonly Dictionary<string, (short X, short Y)> StoredPositions = [];
 
-    private static readonly HashSet<string> JobAddonNames = [.. ElementUtil.GetAddonName(Element.Job)
+    private static readonly HashSet<string> IgnoreHudLayoutSettingAddonNames = [.. ElementUtil.GetAddonName(Element.Job)
         .Concat(ElementUtil.GetAddonName(Element.CrossHotbar))];
 
     #region Visibility and Position
@@ -32,7 +32,7 @@ public static unsafe class Addon
     /// </summary>
     public static float GetSavedOpacity(string addonName)
     {
-        if (JobAddonNames.Contains(addonName))
+        if (IgnoreHudLayoutSettingAddonNames.Contains(addonName))
             return 1.0f;
 
         var config = AddonConfig.Instance();

--- a/FaderPlugin/Addon.cs
+++ b/FaderPlugin/Addon.cs
@@ -48,7 +48,7 @@ public static unsafe class Addon
             if (!addons[i].HasValue) continue;
             if (addons[i].AddonNameHash != addonNameHash) continue;
 
-            // all special HudElements that don't have an opacity slider have an alpha of 0. Elements that do have a slider only go down to ~0,1
+            // all special HudElements that don't have an opacity slider have an alpha value of 0. Elements that do have a slider only go down to ~0,1
             if (addons[i].Alpha == 0)
                 return 1.0f;
 

--- a/FaderPlugin/Addon.cs
+++ b/FaderPlugin/Addon.cs
@@ -48,7 +48,7 @@ public static unsafe class Addon
             if (!addons[i].HasValue) continue;
             if (addons[i].AddonNameHash != addonNameHash) continue;
 
-            // all special HudElements that don't have a opacity slider have an alpha of 0. Elements that do have a slider only go down to ~0,1
+            // all special HudElements that don't have an opacity slider have an alpha of 0. Elements that do have a slider only go down to ~0,1
             if (addons[i].Alpha == 0)
                 return 1.0f;
 

--- a/FaderPlugin/Addon.cs
+++ b/FaderPlugin/Addon.cs
@@ -23,7 +23,8 @@ public static unsafe class Addon
     private static readonly Dictionary<string, (short X, short Y)> StoredPositions = [];
 
     private static readonly HashSet<string> IgnoreHudLayoutSettingAddonNames = [.. ElementUtil.GetAddonName(Element.Job)
-        .Concat(ElementUtil.GetAddonName(Element.CrossHotbar))];
+        .Concat(ElementUtil.GetAddonName(Element.CrossHotbar))
+        .Concat(ElementUtil.GetAddonName(Element.CosmicAnnouncements))];
 
     #region Visibility and Position
 

--- a/FaderPlugin/Addon.cs
+++ b/FaderPlugin/Addon.cs
@@ -22,10 +22,6 @@ public static unsafe class Addon
 
     private static readonly Dictionary<string, (short X, short Y)> StoredPositions = [];
 
-    private static readonly HashSet<string> IgnoreHudLayoutSettingAddonNames = [.. ElementUtil.GetAddonName(Element.Job)
-        .Concat(ElementUtil.GetAddonName(Element.CrossHotbar))
-        .Concat(ElementUtil.GetAddonName(Element.CosmicAnnouncements))];
-
     #region Visibility and Position
 
     /// <summary>
@@ -33,9 +29,6 @@ public static unsafe class Addon
     /// </summary>
     public static float GetSavedOpacity(string addonName)
     {
-        if (IgnoreHudLayoutSettingAddonNames.Contains(addonName))
-            return 1.0f;
-
         var config = AddonConfig.Instance();
         if (config == null || config->ActiveDataSet == null)
             return 1.0f;
@@ -56,6 +49,10 @@ public static unsafe class Addon
         {
             if (!addons[i].HasValue) continue;
             if (addons[i].AddonNameHash != addonNameHash) continue;
+
+            // all special HudElements that don't have a opacity slider have an alpha of 0. Elements that do have a slider only go down to ~0,1
+            if (addons[i].Alpha == 0)
+                return 1.0f;
 
             return addons[i].Alpha / 255f;
         }

--- a/FaderPlugin/Addon.cs
+++ b/FaderPlugin/Addon.cs
@@ -10,6 +10,7 @@ using FFXIVClientStructs.FFXIV.Component.GUI;
 using Lumina.Misc;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Numerics;
 
 namespace FaderPlugin;
@@ -21,7 +22,8 @@ public static unsafe class Addon
 
     private static readonly Dictionary<string, (short X, short Y)> StoredPositions = [];
 
-    private static readonly HashSet<string> JobAddonNames = [.. ElementUtil.GetAddonName(Element.Job)];
+    private static readonly HashSet<string> JobAddonNames = [.. ElementUtil.GetAddonName(Element.Job)
+        .Concat(ElementUtil.GetAddonName(Element.CrossHotbar))];
 
     #region Visibility and Position
 

--- a/FaderPlugin/Addon.cs
+++ b/FaderPlugin/Addon.cs
@@ -1,5 +1,4 @@
 using Dalamud.Game.ClientState.GamePad;
-using FaderPlugin.Data;
 using FFXIVClientStructs.FFXIV.Client.Game.Fate;
 using FFXIVClientStructs.FFXIV.Client.Game.UI;
 using FFXIVClientStructs.FFXIV.Client.Graphics;
@@ -10,7 +9,6 @@ using FFXIVClientStructs.FFXIV.Component.GUI;
 using Lumina.Misc;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Numerics;
 
 namespace FaderPlugin;

--- a/FaderPlugin/Data/Element.cs
+++ b/FaderPlugin/Data/Element.cs
@@ -52,6 +52,7 @@ public enum Element
     BozjaHud = 41,
     EurekaElementalHud = 42,
     EurekaLogosHud = 43,
+    CosmicAnnouncements = 44
 
 }
 
@@ -80,6 +81,7 @@ public static class ElementUtil
             Element.ScenarioGuide => Language.ElementScenarioGuide,
             Element.IslekeepIndex => Language.ElementIslekeepIndex,
             Element.CosmicExotablet => Language.ElementCosmicExotablet,
+            Element.CosmicAnnouncements => Language.ElementCosmicAnnouncements,
             Element.EurekaElementalHud => Language.ElementEurekaElementalHud,
             Element.EurekaLogosHud => Language.ElementEurekaLogosHud,
             Element.BozjaHud => Language.ElementBozjaHud,
@@ -173,6 +175,7 @@ public static class ElementUtil
             Element.ServerInfo => ["_DTR"],
             Element.IslekeepIndex => ["MJIHud"],
             Element.CosmicExotablet => ["WKSHud"],
+            Element.CosmicAnnouncements => ["WKSAnnounce"],
             Element.OccultCrescentHud => ["MKDInfo"],
             Element.BozjaHud => ["MYCInfo"],
             Element.EurekaElementalHud => ["EurekaElementalHud"],
@@ -256,6 +259,7 @@ public static class ElementUtil
         Element.ServerInfo,
         Element.IslekeepIndex,
         Element.CosmicExotablet,
+        Element.CosmicAnnouncements,
         Element.EurekaElementalHud,
         Element.EurekaLogosHud,
         Element.BozjaHud,

--- a/FaderPlugin/Resources/Language.Designer.cs
+++ b/FaderPlugin/Resources/Language.Designer.cs
@@ -178,6 +178,15 @@ namespace faderPlugin.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cosmic Exploration Info.
+        /// </summary>
+        internal static string ElementCosmicAnnouncements {
+            get {
+                return ResourceManager.GetString("ElementCosmicAnnouncements", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cosmic Exotablet.
         /// </summary>
         internal static string ElementCosmicExotablet {

--- a/FaderPlugin/Resources/Language.de.resx
+++ b/FaderPlugin/Resources/Language.de.resx
@@ -159,4 +159,7 @@
   <data name="SettingsRelativeOpacity" xml:space="preserve">
     <value />
   </data>
+  <data name="ElementCosmicAnnouncements" xml:space="preserve">
+    <value />
+  </data>
 </root>

--- a/FaderPlugin/Resources/Language.fr.resx
+++ b/FaderPlugin/Resources/Language.fr.resx
@@ -159,4 +159,7 @@
   <data name="SettingsRelativeOpacity" xml:space="preserve">
     <value />
   </data>
+  <data name="ElementCosmicAnnouncements" xml:space="preserve">
+    <value />
+  </data>
 </root>

--- a/FaderPlugin/Resources/Language.ja.resx
+++ b/FaderPlugin/Resources/Language.ja.resx
@@ -159,4 +159,7 @@
   <data name="SettingsRelativeOpacity" xml:space="preserve">
     <value />
   </data>
+  <data name="ElementCosmicAnnouncements" xml:space="preserve">
+    <value />
+  </data>
 </root>

--- a/FaderPlugin/Resources/Language.resx
+++ b/FaderPlugin/Resources/Language.resx
@@ -513,4 +513,7 @@ E.g., native 60% * plugin 50% → resulting UI at 30%.</value>
   <data name="SettingsRelativeOpacity" xml:space="preserve">
     <value>Relative Opacity</value>
   </data>
+  <data name="ElementCosmicAnnouncements" xml:space="preserve">
+    <value>Cosmic Exploration Info</value>
+  </data>
 </root>


### PR DESCRIPTION
- fixed Jobbars & Cross Hotbar oddity of being a native HUDLayout option that does not have an opacity slider
- add cosmic exploration info as new element (Mech Ops alert)