### PR TITLE
Improve config list layout with localized text

### DIFF
--- a/FaderPlugin/Windows/Config/ConfigWindow.HoverGroups.cs
+++ b/FaderPlugin/Windows/Config/ConfigWindow.HoverGroups.cs
@@ -21,10 +21,7 @@ public partial class ConfigWindow
             return;
 
         var style = ImGui.GetStyle();
-        var buttonWidth = ImGui.CalcTextSize("Context Action Hotbar   ?").X
-                          + style.FramePadding.X * 2
-                          + style.ScrollbarSize;
-        var childSize = buttonWidth + style.WindowPadding.X * 2;
+        var (buttonWidth, childSize) = GetElementListSizes();  // sync width
 
         // Left Pane: List of groups.
         using (var leftChild = ImRaii.Child("HoverGroupsList", new Vector2(childSize, 0), true))
@@ -53,7 +50,7 @@ public partial class ConfigWindow
                     }
                     if (ImGui.IsItemHovered())
                     {
-                        var addonNames = group.Elements.SelectMany(element => ElementUtil.GetAddonName(element)).ToArray();
+                        var addonNames = group.Elements.SelectMany(ElementUtil.GetAddonName).ToArray();
                         if (addonNames.Length == 0)
                             continue;
 
@@ -100,11 +97,13 @@ public partial class ConfigWindow
             }
 
             // right align delete button.
-            var deleteButtonMargin = ImGui.GetContentRegionAvail().X - 15;
-            ImGui.SameLine(deleteButtonMargin);
+            var deleteIcon = FontAwesomeIcon.TrashAlt.ToIconString();
             using (ImRaii.PushFont(UiBuilder.IconFont))
             {
-                if (ImGui.Button($"{FontAwesomeIcon.TrashAlt.ToIconString()}##{groupName}-delete"))
+                var deleteButtonWidth = ImGui.CalcTextSize(deleteIcon).X + ImGui.GetStyle().FramePadding.X * 2;
+                ImGui.SameLine(ImGui.GetContentRegionAvail().X - deleteButtonWidth);
+
+                if (ImGui.Button($"{deleteIcon}##{groupName}-delete"))
                 {
                     Configuration.HoverGroups.RemoveAt(SelectedHoverGroupIndex);
                     SelectedHoverGroupIndex = -1;

--- a/FaderPlugin/Windows/Config/ConfigWindow.Settings.cs
+++ b/FaderPlugin/Windows/Config/ConfigWindow.Settings.cs
@@ -20,6 +20,7 @@ public partial class ConfigWindow
     private readonly List<Element> SelectedElements = [];
     private const float AlphaTolerance = 1f / 255f;
     private Constants.OverrideKeys CurrentOverrideKey => (Constants.OverrideKeys)Configuration.OverrideKey;
+    private const string ElementTooltipIndicator = "   ?";
 
     private void Settings()
     {
@@ -32,12 +33,10 @@ public partial class ConfigWindow
         if (ImGui.CollapsingHeader(Language.SettingsGeneralHeader, ImGuiTreeNodeFlags.DefaultOpen))
         {
             // Create a 2-column table to align labels and controls.
-            // Increase widths so longer text doesn't get cut off.
             using var table = ImRaii.Table("FaderSettingsTable", 2, ImGuiTableFlags.SizingFixedFit | ImGuiTableFlags.NoSavedSettings);
             if (table.Success)
             {
-                // Adjust column widths to give more space to labels.
-                ImGui.TableSetupColumn("Label", ImGuiTableColumnFlags.WidthFixed, 300.0f * ImGuiHelpers.GlobalScale);
+                ImGui.TableSetupColumn("Label", ImGuiTableColumnFlags.WidthFixed);  // Auto-fit under SizingFixedFit.
                 ImGui.TableSetupColumn("Control", ImGuiTableColumnFlags.WidthFixed, 220.0f * ImGuiHelpers.GlobalScale);
 
                 //
@@ -228,8 +227,7 @@ public partial class ConfigWindow
         // Layout for element selection + config
         var startPos = ImGui.GetCursorPos();
         var style = ImGui.GetStyle();
-        var buttonWidth = ImGui.CalcTextSize("Context Action Hotbar   ?").X + style.FramePadding.X * 2 + style.ScrollbarSize;
-        var childSize = buttonWidth + style.WindowPadding.X * 2;
+        var (buttonWidth, childSize) = GetElementListSizes();
 
         #region Left Child : Element Selection
         using (var child = ImRaii.Child("ElementList", new Vector2(childSize, 0), true))
@@ -241,10 +239,8 @@ public partial class ConfigWindow
                     if (element.ShouldIgnoreElement())
                         continue;
 
-                    var buttonText = ElementUtil.GetElementName(element);
+                    var buttonText = GetElementListButtonText(element);
                     var tooltipText = element.TooltipForElement();
-                    if (!string.IsNullOrEmpty(tooltipText))
-                        buttonText += "   ?";
 
                     using var pushedStyle = ImRaii.PushStyle(ImGuiStyleVar.ButtonTextAlign, new Vector2(0, 0.5f));
 
@@ -524,5 +520,28 @@ public partial class ConfigWindow
         }
 
         Configuration.Save();
+    }
+
+    private static (float ButtonWidth, float ChildWidth) GetElementListSizes()
+    {
+        var style = ImGui.GetStyle();
+
+        var maxTextWidth = ElementUtil.OrderedElements
+            .Where(element => !element.ShouldIgnoreElement())
+            .Select(element => ImGui.CalcTextSize(GetElementListButtonText(element)).X)
+            .DefaultIfEmpty(0.0f)
+            .Max();
+
+        var buttonWidth = maxTextWidth + style.FramePadding.X * 2 + style.ScrollbarSize;
+        var childWidth = buttonWidth + style.WindowPadding.X * 2;
+        return (buttonWidth, childWidth);
+    }
+
+    private static string GetElementListButtonText(Element element)
+    {
+        var elementName = ElementUtil.GetElementName(element);
+        var tooltipText = element.TooltipForElement();
+
+        return string.IsNullOrEmpty(tooltipText) ? elementName : $"{elementName}{ElementTooltipIndicator}";
     }
 }


### PR DESCRIPTION
## Details

- Measure config element list width from the actual visible button text, including tooltip indicators.
- Replace hard-coded delete-button alignment with icon-width-based positioning.
- Minor cleanup around hover group addon-name projection.

## Testing

### Before
<img width="1222" height="1169" alt="image" src="https://github.com/user-attachments/assets/2829a229-21a1-42bb-b086-286dae9469db" />
<img width="1225" height="680" alt="image" src="https://github.com/user-attachments/assets/ae2e018d-b9c4-4466-a02a-6ea25780bf02" />

### After
<img width="1221" height="1165" alt="image" src="https://github.com/user-attachments/assets/4e7cbcfb-3aa3-4897-8f00-9523e7679261" />
<img width="1222" height="1169" alt="image" src="https://github.com/user-attachments/assets/79d47d57-0265-4ec5-b5ac-ee9f38216b7a" />

---

After this change, the element list width is calculated from the longest localized visible button text, so the list should adapt better across different localizations and reduce unintended clipping.

I am using the CN client, so my testing is limited to the existing English strings and the new zh localization added in https://github.com/Infiziert90/xivFaderPlugin/pull/24.